### PR TITLE
boot support cleanup

### DIFF
--- a/kas/base.yaml
+++ b/kas/base.yaml
@@ -61,6 +61,7 @@ local_conf_header:
         IMAGE_FSTYPES:append = " wic"
         IMAGE_INSTALL:remove = "distro-feed-configs"
         CORE_IMAGE_EXTRA_INSTALL:append = " nano hellogitcmake"
+        EXTRA_IMAGEDEPENDS:append = " u-boot-script-vctlabs"
         EXTRA_IMAGE_FEATURES:append = " package-management ssh-server-openssh"
         EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
         require conf/distro/include/no-static-libs.inc

--- a/kas/enclustra.yaml
+++ b/kas/enclustra.yaml
@@ -10,9 +10,9 @@ machine: me-aa1-270-2i2-d11e-nfx3
 env:
     PACKAGE_FEED_IP_PORT: "192.168.7.150:8000"
     PACKAGE_FEED_TYPE: ipk
-    UBOOT_CONFIG: sdmmc
+    #UBOOT_CONFIG: sdmmc
     #UBOOT_CONFIG: emmc
-    #UBOOT_CONFIG: qspi
+    UBOOT_CONFIG: qspi
 
 local_conf_header:
     dev: |

--- a/kas/sysvinit.yaml
+++ b/kas/sysvinit.yaml
@@ -8,4 +8,3 @@ local_conf_header:
   sysvinit: |
         DISTRO_FEATURES:remove = " systemd"
         VIRTUAL-RUNTIME_init_manager = "sysvinit"
-        CORE_IMAGE_EXTRA_INSTALL:append = " resize-rootfs"

--- a/recipes-bsp/u-boot-script/u-boot-script-vctlabs_2023.01.bb
+++ b/recipes-bsp/u-boot-script/u-boot-script-vctlabs_2023.01.bb
@@ -38,4 +38,4 @@ addtask deploy after do_install before do_build
 do_compile[noexec] = "1"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "(me-aa1-270-2i2-d11e-nfx3|refdes-me-aa1-270-2i2-d11e-nfx3-st1)"
+COMPATIBLE_MACHINE = "(st1-baseboard|me-aa1-270-2i2-d11e-nfx3|refdes-me-aa1-270-2i2-d11e-nfx3-st1)"

--- a/recipes-core/images/devel-image-minimal.bb
+++ b/recipes-core/images/devel-image-minimal.bb
@@ -13,7 +13,6 @@ inherit core-image
 
 IMAGE_INSTALL:append = "\
     ${CORE_IMAGE_EXTRA_INSTALL} \
-    resize-rootfs \
 "
 
 WKS_FILE ??= "devel-image-minimal.wks"


### PR DESCRIPTION
* remove resize-rootfs install and restore u-boot script recipe depends
* (re)set qspi as default boot mode to align with vendor defaults (does not affect workflow commands)
* add generic machine override to flash script recipe